### PR TITLE
feat: implement PayPal Orders v2 tracking APIs

### DIFF
--- a/src/endpoints/orders/endpoint.rs
+++ b/src/endpoints/orders/endpoint.rs
@@ -1,1 +1,46 @@
+use crate::framework::endpoint::{EndpointSpec, Method, RequestBody};
+use crate::endpoints::orders::{AddOrderTracking, AddTrackingResponse, ReceiveOrderUpdateCallback, UpdateOrCancelOrderTracking};
+use crate::endpoints::orders::response::CallbackResponse;
+
+impl EndpointSpec for AddOrderTracking {
+    type ResponseType = AddTrackingResponse;
+    fn method(&self) -> Method {
+        Method::POST
+    }
+    fn path(&self) -> String {
+        format!("/v2/checkout/orders/{}/track", self.order_id)
+    }
+    fn body(&self) -> Option<RequestBody> {
+        let json = serde_json::to_string(&self.tracking_request).unwrap();
+        Some(RequestBody::Json(json))
+    }
+}
+
+impl EndpointSpec for UpdateOrCancelOrderTracking {
+    type ResponseType = ();
+    fn method(&self) -> Method {
+        Method::PATCH
+    }
+    fn path(&self) -> String {
+        format!("/v2/checkout/orders/{}/trackers/{}", self.order_id, self.tracker_id)
+    }
+    fn body(&self) -> Option<RequestBody> {
+        let json = serde_json::to_string(&self.operations).unwrap();
+        Some(RequestBody::Json(json))
+    }
+}
+
+impl EndpointSpec for ReceiveOrderUpdateCallback {
+    type ResponseType = CallbackResponse;
+    fn method(&self) -> Method {
+        Method::POST
+    }
+    fn path(&self) -> String {
+        "/v2/checkout/orders/callback".to_string()
+    }
+    fn body(&self) -> Option<RequestBody> {
+        let json = serde_json::to_string(&self.payload).unwrap();
+        Some(RequestBody::Json(json))
+    }
+}
 

--- a/src/endpoints/orders/mod.rs
+++ b/src/endpoints/orders/mod.rs
@@ -1,4 +1,8 @@
 mod endpoint;
-mod request;
-mod response;
-mod schema;
+pub mod request;
+pub mod response;
+pub mod schema;
+
+pub use endpoint::*;
+pub use request::*;
+pub use response::*;

--- a/src/endpoints/orders/request.rs
+++ b/src/endpoints/orders/request.rs
@@ -1,1 +1,29 @@
+use typed_builder::TypedBuilder;
+use crate::endpoints::orders::schema::tracking::{JsonPatchOperation, TrackingRequest, CallbackPayload};
+
+#[derive(Debug, Clone, TypedBuilder)]
+pub struct AddOrderTracking {
+    #[builder(setter(into))]
+    pub order_id: String,
+
+    #[builder(setter(into))]
+    pub tracking_request: TrackingRequest,
+}
+
+#[derive(Debug, Clone, TypedBuilder)]
+pub struct UpdateOrCancelOrderTracking {
+    #[builder(setter(into))]
+    pub order_id: String,
+
+    #[builder(setter(into))]
+    pub tracker_id: String,
+
+    #[builder(setter(into))]
+    pub operations: Vec<JsonPatchOperation>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReceiveOrderUpdateCallback {
+    pub payload: CallbackPayload,
+}
 

--- a/src/endpoints/orders/response.rs
+++ b/src/endpoints/orders/response.rs
@@ -1,1 +1,128 @@
+use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddTrackingResponse {
+    pub id: String,
+    pub status: String,
+    pub purchase_units: Vec<PurchaseUnit>,
+    pub links: Vec<HateoasLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PurchaseUnit {
+    pub reference_id: String,
+    pub items: Vec<OrderItem>,
+    pub shipping: Option<Shipping>,
+    pub payments: Option<Payments>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrderItem {
+    pub name: String,
+    pub sku: String,
+    pub quantity: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Shipping {
+    pub trackers: Vec<Tracker>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tracker {
+    pub id: String,
+    pub links: Vec<HateoasLink>,
+    pub create_time: Option<String>,
+    pub update_time: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Payments {
+    pub captures: Vec<Capture>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Capture {
+    pub id: String,
+    pub status: String,
+    pub amount: Amount,
+    pub seller_protection: Option<SellerProtection>,
+    pub final_capture: Option<bool>,
+    pub seller_receivable_breakdown: Option<SellerReceivableBreakdown>,
+    pub create_time: Option<String>,
+    pub update_time: Option<String>,
+    pub links: Vec<HateoasLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Amount {
+    pub currency_code: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SellerProtection {
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SellerReceivableBreakdown {
+    pub gross_amount: Amount,
+    pub paypal_fee: Amount,
+    pub net_amount: Amount,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HateoasLink {
+    pub href: String,
+    pub rel: String,
+    pub method: String,
+}
+
+impl crate::framework::response::JsonResult for AddTrackingResponse {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallbackResponse {
+    pub id: String,
+    pub purchase_units: Vec<CallbackPurchaseUnit>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallbackPurchaseUnit {
+    pub reference_id: String,
+    pub amount: CallbackAmount,
+    pub shipping_options: Vec<ShippingOption>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallbackAmount {
+    pub currency_code: String,
+    pub value: String,
+    pub breakdown: Option<AmountBreakdown>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AmountBreakdown {
+    pub item_total: Option<Amount>,
+    pub tax_total: Option<Amount>,
+    pub shipping: Option<Amount>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShippingOption {
+    pub id: String,
+    pub amount: ShippingAmount,
+    #[serde(rename = "type")]
+    pub shipping_type: String,
+    pub label: String,
+    pub selected: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShippingAmount {
+    #[serde(rename = "currencyCode")]
+    pub currency_code: String,
+    pub value: String,
+}
+
+impl crate::framework::response::JsonResult for CallbackResponse {}

--- a/src/endpoints/orders/schema/mod.rs
+++ b/src/endpoints/orders/schema/mod.rs
@@ -10,6 +10,7 @@ mod payee;
 mod shipping;
 mod source;
 mod supplementary;
+pub mod tracking;
 pub mod unit;
 pub mod upc;
 

--- a/src/endpoints/orders/schema/tracking.rs
+++ b/src/endpoints/orders/schema/tracking.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
+pub struct TrackingRequest {
+    #[builder(setter(into))]
+    pub capture_id: String,
+
+    #[builder(setter(into))]
+    pub tracking_number: String,
+
+    #[builder(setter(into))]
+    pub carrier: String,
+
+    #[builder(setter(strip_bool))]
+    pub notify_payer: bool,
+
+    #[builder(default)]
+    pub items: Vec<TrackingItem>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
+pub struct TrackingItem {
+    #[builder(default, setter(strip_option, into))]
+    pub sku: Option<String>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub quantity: Option<String>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub name: Option<String>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub description: Option<String>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub image_url: Option<String>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub url: Option<String>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub upc: Option<UpcCode>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
+pub struct UpcCode {
+    #[builder(setter(into))]
+    #[serde(rename = "type")]
+    pub upc_type: String,
+
+    #[builder(setter(into))]
+    pub code: String,
+}
+
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
+pub struct JsonPatchOperation {
+    #[builder(setter(into))]
+    pub op: String,
+
+    #[builder(setter(into))]
+    pub path: String,
+
+    #[builder(default, setter(strip_option))]
+    pub value: Option<serde_json::Value>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub from: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
+pub struct OrderUpdateCallback {
+    #[builder(setter(into))]
+    pub id: String,
+
+    #[builder(setter(into))]
+    pub intent: String,
+
+    #[builder(setter(into))]
+    pub status: String,
+
+    #[builder(default)]
+    pub purchase_units: Vec<serde_json::Value>,
+
+    #[builder(default, setter(strip_option))]
+    pub payer: Option<serde_json::Value>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub create_time: Option<String>,
+
+    #[builder(default, setter(strip_option, into))]
+    pub update_time: Option<String>,
+
+    #[builder(default)]
+    pub links: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
+pub struct CallbackPayload {
+    #[builder(setter(into))]
+    pub id: String,
+
+    #[builder(setter(into))]
+    pub event_version: String,
+
+    #[builder(setter(into))]
+    pub create_time: String,
+
+    #[builder(setter(into))]
+    pub resource_type: String,
+
+    #[builder(setter(into))]
+    pub resource_version: String,
+
+    #[builder(setter(into))]
+    pub event_type: String,
+
+    #[builder(setter(into))]
+    pub summary: String,
+
+    #[builder(setter(into))]
+    pub resource: OrderUpdateCallback,
+
+    #[builder(default, setter(strip_option))]
+    pub links: Vec<serde_json::Value>,
+}


### PR DESCRIPTION
- Add tracking information for an order (POST /v2/checkout/orders/{id}/track)
- Update or cancel tracking information (PATCH /v2/checkout/orders/{id}/trackers/{tracker_id})  
- Receive updated order information via callback URL (POST /v2/checkout/orders/callback)

API structures:
- AddOrderTracking with TrackingRequest, TrackingItem, UpcCode schemas
- UpdateOrCancelOrderTracking with JsonPatchOperation schema
- ReceiveOrderUpdateCallback with CallbackPayload, OrderUpdateCallback schemas

Response types:
- AddTrackingResponse with complete order details (200/201 status)
- CallbackResponse with purchase units and shipping options (200 status)
- Empty response for UpdateOrCancelOrderTracking (200 status)

All schemas properly organized:
- request.rs: Request types and endpoint structs
- response.rs: Response types and response schemas  
- schema/tracking.rs: Internal request schemas with TypedBuilder support"